### PR TITLE
fix

### DIFF
--- a/src/components/input-number/input-number.vue
+++ b/src/components/input-number/input-number.vue
@@ -18,7 +18,7 @@
             <input
                 :class="inputClasses"
                 :disabled="disabled"
-                autoComplete="off"
+                autocomplete="off"
                 @focus="focus"
                 @blur="blur"
                 @keydown.stop="keyDown"


### PR DESCRIPTION
Found camelCase attribute: autoComplete="off". HTML is case-insensitive. Use auto-complete="off" instead. Vue will automatically interpret it as camelCase in JavaScript. If this is an SVG camelCase attribute, use the .camel modifier.